### PR TITLE
Fix invalid ITOW extraction from ubx data.

### DIFF
--- a/lib/sylphide_communicator.rb
+++ b/lib/sylphide_communicator.rb
@@ -95,8 +95,9 @@ module Mv
         @properties[:omega] = res[:omega]
       when SylphideProcessor::GPacketObserver
         increment_packet_count :g
-        @properties[:itow] = observer.fetch_ITOW
         case ubx_id16(observer)
+        when 0x0101, 0x0102, 0x0108, 0x0111, 0x0112 # NAV-POSXXX, NAV-VELXXX
+          @properties[:itow] = observer.fetch_ITOW
         when 0x0130#space vehicle information
           satellites = []
           n_ch = observer.channels
@@ -113,7 +114,8 @@ module Mv
             end
           }
           @properties[:satellites] = satellites
-        when 0x0210
+        when 0x0210 # RXM-RAW
+          @properties[:itow] = observer.fetch_ITOW
           @properties[:num_sv] = observer.num_of_sv
         end
       when SylphideProcessor::FPacketObserver


### PR DESCRIPTION
Some kinds of G packets represented by RXM-SFRB (0x0211), and RXM-EPH
(0x0231) do not provide ITOW information. Therefore, before the
extraction, which kind of a G packet must be checked.
